### PR TITLE
Compat : Planner - Calendar paging changes status colors

### DIFF
--- a/PublishPress_Statuses.php
+++ b/PublishPress_Statuses.php
@@ -1142,6 +1142,10 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
         }
 
         if (is_null($post_type)) {
+            if (defined('DOING_AJAX') && DOING_AJAX) {
+                return false;
+            }
+
             $post_type = self::getCurrentPostType();
         }
 


### PR DESCRIPTION
 If one or more post types have Statuses integration disabled, customized status colors are not applied to paged results on Planner Content Calendar