### PR TITLE
Post editor: misplaced function causes js error on some sites

### DIFF
--- a/common/js/custom-status-block-legacy.dev.js
+++ b/common/js/custom-status-block-legacy.dev.js
@@ -492,29 +492,6 @@ setInterval(function () {
   });
 });
 
-
-var ppcsDisablePostUpdate = function ppDisablePostUpdate() {
-  $('span.presspermit-editor-toggle button').attr('aria-disabled', true);
-  $('span.presspermit-editor-button button').attr('aria-disabled', true);
-  $('div.publishpress-extended-post-status select').attr('disabled', true);
-}
-
-var ppcsEnablePostUpdate = function ppEnablePostUpdate() {
-  jQuery(document).ready(function ($) {
-    var intRestoreToggle = setInterval(function() {
-      if ($('span.presspermit-editor-toggle button:visible').length && $('span.presspermit-editor-toggle button').parent().prev('button').attr('aria-disabled') == 'false'
-      || ($('span.presspermit-editor-button button:visible').length && $('span.presspermit-editor-button button').parent().prev('button').attr('aria-disabled') == 'false')
-      ) {
-        $('span.presspermit-editor-toggle button').removeAttr('aria-disabled');
-        $('span.presspermit-editor-button button').removeAttr('aria-disabled');
-        clearInterval(intRestoreToggle);
-      }
-    }, 100);
-
-    $('div.publishpress-extended-post-status select').removeAttr('disabled');
-  });
-}
-
 /**
  * Custom status component
  * @param object props

--- a/common/js/custom-status-block.dev.js
+++ b/common/js/custom-status-block.dev.js
@@ -605,29 +605,6 @@ setInterval(function () {
   });
 });
 
-
-var ppcsDisablePostUpdate = function ppDisablePostUpdate() {
-  $('span.presspermit-editor-toggle button').attr('aria-disabled', true);
-  $('span.presspermit-editor-button button').attr('aria-disabled', true);
-  $('div.publishpress-extended-post-status select').attr('disabled', true);
-}
-
-var ppcsEnablePostUpdate = function ppEnablePostUpdate() {
-  jQuery(document).ready(function ($) {
-    var intRestoreToggle = setInterval(function() {
-      if ($('span.presspermit-editor-toggle button:visible').length && $('span.presspermit-editor-toggle button').parent().prev('button').attr('aria-disabled') == 'false'
-      || ($('span.presspermit-editor-button button:visible').length && $('span.presspermit-editor-button button').parent().prev('button').attr('aria-disabled') == 'false')
-      ) {
-        $('span.presspermit-editor-toggle button').removeAttr('aria-disabled');
-        $('span.presspermit-editor-button button').removeAttr('aria-disabled');
-        clearInterval(intRestoreToggle);
-      }
-    }, 100);
-
-    $('div.publishpress-extended-post-status select').removeAttr('disabled');
-  });
-}
-
 /**
  * Custom status component
  * @param object props

--- a/common/js/post-block-edit.dev.js
+++ b/common/js/post-block-edit.dev.js
@@ -312,6 +312,30 @@ jQuery(document).ready(function ($) {
         }
     });
 
+    var ppcsDisablePostUpdate = function ppDisablePostUpdate() {
+    jQuery(document).ready(function ($) {
+        $('span.presspermit-editor-toggle button').attr('aria-disabled', true);
+        $('span.presspermit-editor-button button').attr('aria-disabled', true);
+        $('div.publishpress-extended-post-status select').attr('disabled', true);
+    });
+    }
+    
+    var ppcsEnablePostUpdate = function ppEnablePostUpdate() {
+    jQuery(document).ready(function ($) {
+        var intRestoreToggle = setInterval(function() {
+        if ($('span.presspermit-editor-toggle button:visible').length && $('span.presspermit-editor-toggle button').parent().prev('button').attr('aria-disabled') == 'false'
+        || ($('span.presspermit-editor-button button:visible').length && $('span.presspermit-editor-button button').parent().prev('button').attr('aria-disabled') == 'false')
+        ) {
+            $('span.presspermit-editor-toggle button').removeAttr('aria-disabled');
+            $('span.presspermit-editor-button button').removeAttr('aria-disabled');
+            clearInterval(intRestoreToggle);
+        }
+        }, 100);
+    
+        $('div.publishpress-extended-post-status select').removeAttr('disabled');
+    });
+    }
+
     let ppPostSavingDone = function() {
         $('div.publishpress-extended-post-status select').removeAttr('locked');
 


### PR DESCRIPTION
Function ppcsEnablePostUpdate() is called in post-block-edit.js, but defined in custom-status-block.js

#279