### PR TITLE
Implement Default Visibility, Lock Visibility and Prevent Unpublishing features

### DIFF
--- a/PostEdit.php
+++ b/PostEdit.php
@@ -29,12 +29,102 @@ class PostEdit
         }
 
         add_action('admin_head', [$this, 'act_status_labels_structural_check_and_supplement'], 5);
+
+        global $pagenow;
+
+        $post_type = \PublishPress_Functions::findPostType();
+
+        $options = \PublishPress_Statuses::instance()->options;
+        $default_privacy = (is_object($options) && !empty($options->default_privacy) && !empty($options->default_privacy[$post_type])) ? $options->default_privacy[$post_type] : '';
+
+        if ($post_type && $default_privacy) {
+            if (\PublishPress_Functions::isBlockEditorActive($post_type)) {
+                // separate JS for Gutenberg
+                if (in_array($pagenow, ['post-new.php'])) {
+                    add_action('admin_print_scripts', [$this, 'default_privacy_gutenberg']);
+                }
+            } else {
+                add_action('admin_footer', [$this, 'default_privacy_js']);
+            }
+        }
     }
 
     public function actLoadGutenbergScripts() {
         require_once(__DIR__ . '/PostEditGutenberg.php');
         $obj = new \PublishPress_Statuses\PostEditGutenberg();
         $obj->actEnqueueBlockEditorAssets();
+    }
+
+
+    function default_privacy_gutenberg() {
+        // Pass default_privacy setting to JavaScript for Gutenberg
+        $post_type = \PublishPress_Functions::findPostType();
+
+        $options = \PublishPress_Statuses::instance()->options;
+        $default_privacy = (is_object($options) && !empty($options->default_privacy) && !empty($options->default_privacy[$post_type])) ? $options->default_privacy[$post_type] : '';
+
+        wp_localize_script('publishpress-statuses-post-edit', 'ppEditorConfig', ['defaultPrivacy' => $default_privacy]);
+    }
+
+    function default_privacy_js()
+    {
+        global $post, $typenow;
+
+        if ('post-new.php' != $GLOBALS['pagenow']) {
+            $stati = get_post_stati(['public' => true, 'private' => true], 'names', 'or');
+
+            if (in_array($post->post_status, $stati, true)) {
+                return;
+            }
+        }
+
+        $options = \PublishPress_Statuses::instance()->options;
+        $set_visibility = (is_object($options) && !empty($options->default_privacy) && !empty($options->default_privacy[$typenow])) ? $options->default_privacy[$typenow] : '';
+
+        if (!$set_visibility) {
+            return;
+        }
+
+        if (is_numeric($set_visibility) || !get_post_status_object($set_visibility)) {
+            $set_visibility = 'private';
+        }
+?>
+        <script type="text/javascript">
+            /* <![CDATA[ */
+            jQuery(document).ready(function($) {
+                // Check the radio (use 'checked' for radio inputs) and update hidden value
+                var $radio = $('#visibility-radio-<?php echo esc_attr($set_visibility); ?>');
+                $radio.prop('checked', true).trigger('change');
+                $('#hidden-post-visibility').val('<?php echo esc_attr($set_visibility); ?>');
+
+                // Update the visible label. Prefer localized strings if available.
+                if (typeof(postL10n) != 'undefined') {
+                    var vis = $('#post-visibility-select input:radio:checked').val();
+                    var str = '';
+
+                    if ('private' == vis) {
+                        str = '<?php esc_html_e('Private'); ?>';
+                    } else if (postL10n[vis]) {
+                        str = postL10n[vis];
+                    } else {
+                        str = '<?php esc_html_e('Public'); ?>';
+                    }
+
+                    if (str) {
+                        $('#post-visibility-display').html(str);
+                        setTimeout(function() {
+                            $('.save-post-visibility').trigger('click');
+                        }, 0);
+                    }
+                } else {
+                    $('#post-visibility-display').html(
+                        $('#visibility-radio-<?php echo esc_attr($set_visibility); ?>').next('label').html()
+                    );
+                }
+            });
+            /* ]]> */
+        </script>
+        <?php
     }
 
     function act_status_labels_structural_check_and_supplement() {

--- a/PostEditGutenbergStatuses.php
+++ b/PostEditGutenbergStatuses.php
@@ -39,8 +39,7 @@ class PostEditGutenbergStatuses
 
         $default_by_sequence = \PublishPress_Statuses::instance()->workflow_by_sequence;
 
-        if ($args['workflowSequence'] = $default_by_sequence) {
-            $default_by_sequence = true;
+        if ($default_by_sequence) {
             $max_status_obj = \PublishPress_Statuses::defaultStatusProgression($post_id, ['default_by_sequence' => false, 'skip_current_status_check' => true]);
 
             $args['advanceStatus'] = esc_html__('Advance Status', 'publishpress-statuses');
@@ -78,15 +77,28 @@ class PostEditGutenbergStatuses
         }
 
         // Now that logic is done, pass actual Next Status object even if not defaulting to it
-        if (!$args['workflowSequence'] && !defined('PP_STATUSES_SUPPRESS_NEXT_STATUS_SELECTION')) {
+        if (!$default_by_sequence && !defined('PP_STATUSES_SUPPRESS_NEXT_STATUS_SELECTION')) {
             $next_status_obj = \PublishPress_Statuses::defaultStatusProgression(0, ['default_by_sequence' => true]);
         }
 
-        $args = array_merge($args, ['publish' => $publish_label, 'saveAs' => $save_as_label, 'nextStatus' => $next_status_obj->name, 'maxStatus' => $max_status_obj->name, 'defaultBySequence' => !empty($default_by_sequence)]);
+        $post_type = \PublishPress_Functions::findPostType();
+
+        $options = \PublishPress_Statuses::instance()->options;
+        $lock_privacy = (is_object($options) && !empty($options->lock_privacy) && !empty($options->lock_privacy[$post_type])) ? $options->lock_privacy[$post_type] : false;
+
+        $args = array_merge(
+            $args, 
+            [
+                'publish' => $publish_label, 
+                'saveAs' => $save_as_label, 
+                'nextStatus' => $next_status_obj->name, 
+                'maxStatus' => $max_status_obj->name, 
+                'defaultBySequence' => !empty($default_by_sequence),
+                'lockVisibility' => $lock_privacy
+            ]
+        );
 
         if (!$is_administrator = \PublishPress_Statuses::isContentAdministrator()) {
-            $post_type = \PublishPress_Functions::findPostType();
-
             $current_status = get_post_field('post_status', $post_id);
 
             foreach (\PublishPress_Statuses::getPostStati(['moderation' => true, 'post_type' => $post_type]) as $status) {
@@ -141,6 +153,14 @@ class PostEditGutenbergStatuses
         $args['isStatusesPro'] = defined('PUBLISHPRESS_STATUSES_PRO_VERSION');
 
         $args['workflowDisabled'] = \PublishPress_Statuses::instance()->workflow_disabled;
+
+
+        global $pagenow;
+
+        if (in_array($pagenow, ['post-new.php'])) {
+            // Pass default_privacy setting to JavaScript for Gutenberg
+            $args['defaultPrivacy'] = apply_filters('publishpress_statuses_default_visibility', '', $post_type);
+        }
 
         wp_localize_script('publishpress-statuses-post-block-edit', 'ppObjEdit', $args);
     }

--- a/REST.php
+++ b/REST.php
@@ -8,6 +8,7 @@ class REST
     var $endpoint_class = '';
     var $post_type = '';
     var $post_id = 0;
+    var $post_status = '';
     var $is_posts_request = false;
     var $is_terms_request = false;
     var $params = [];
@@ -136,6 +137,25 @@ class REST
                 
                     if ( ! $this->post_id = (!empty($args['id'])) ? $args['id'] : 0 ) {
                         $this->post_id = (!empty($this->params['id'])) ? $this->params['id'] : 0;
+                    }
+
+                    // @todo: is this still needed?
+                    if (('revision' != $this->post_type) && apply_filters('publishpress_statuses_default_visibility', '', $this->post_type)) {
+                        if (false === get_post_meta($this->post_id, '_pp_original_status')) {
+                            global $wpdb;
+
+                            // phpcs Note: When imposing a default privacy, ensure retrieval of stored original status, not newly updated value
+
+                            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+                            if ( $post_status = $wpdb->get_var( 
+                                $wpdb->prepare(
+                                    "SELECT post_status FROM $wpdb->posts WHERE ID = %s", 
+                                    $this->post_id
+                                )
+                            )) {
+                                update_post_meta($this->post_id, '_pp_original_status', $post_status);
+                            }
+                        }
                     }
 
                     if (!$this->post_type) {

--- a/StatusHandler.php
+++ b/StatusHandler.php
@@ -867,6 +867,15 @@ class StatusHandler {
 
                         break;
 
+                    case 'default_privacy':
+                    case 'force_default_privacy':
+                        $new_options[$option_name] = array_intersect_key(
+                            array_map('sanitize_key', (array) $_POST[\PublishPress_Statuses::SETTINGS_SLUG][$option_name]), 
+                            \PublishPress_Statuses::instance()->get_supported_post_types()
+                        );
+
+                        break;
+
                     case 'force_editor_detection':
                     case 'label_storage':
                     case 'moderation_statuses_default_by_sequence':

--- a/common/css/custom-status-admin.css
+++ b/common/css/custom-status-admin.css
@@ -649,6 +649,33 @@ user-select: none;
     color: #000 !important;
 }
 
+
+/* Settings */
+#pp_statuses_default_privacy {
+  display: flex;
+}
+
+#pp_statuses_default_privacy th, #pp_statuses_default_privacy td {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  border-bottom: none;
+  font-weight: inherit;
+  text-align: right;
+}
+
+#pp_statuses_default_privacy th {
+  width: 100px;
+  width: inherit;
+  text-align: right;
+  vertical-align: baseline;
+  padding-right: 0;
+}
+
+#pp_statuses_default_privacy td {
+  vertical-align: baseline;
+}
+
+
 div.pp-statuses-warning {
   background: #fff;
   border: 1px solid #c3c4c7;

--- a/lib/PublishPress_Functions.php
+++ b/lib/PublishPress_Functions.php
@@ -38,13 +38,16 @@ class PublishPress_Functions
             'disable-gutenberg' => class_exists('DisableGutenberg'),
         ];
 
+        if (!empty($args['post_type'])) {
+            $postType = $args['post_type'];
+        } else {
+            if (function_exists('get_post_type')) {
+                $postType = get_post_type();
+            }
 
-        if (function_exists('get_post_type')) {
-            $postType = get_post_type();
-        }
-
-        if (! isset($postType) || empty($postType)) {
-            $postType = 'post';
+            if (!isset($postType) || empty($postType)) {
+                $postType = 'post';
+            }
         }
 
         /**

--- a/publishpress-statuses.php
+++ b/publishpress-statuses.php
@@ -3,7 +3,7 @@
  * Plugin Name: PublishPress Statuses
  * Plugin URI:  https://publishpress.com/statuses
  * Description: Manage and create post statuses to customize your editorial workflow
- * Version: 1.1.14
+ * Version: 1.2.0-rc
  * Author: PublishPress
  * Author URI:  https://publishpress.com/
  * Text Domain: publishpress-statuses
@@ -227,7 +227,7 @@ if ((!defined('PUBLISHPRESS_STATUSES_FILE') && !$pro_active) || $publishpress_st
         }
         
         if (empty($interrupt_load)) {
-            define('PUBLISHPRESS_STATUSES_VERSION', '1.1.14');
+            define('PUBLISHPRESS_STATUSES_VERSION', '1.2.0-rc');
 
             define('PUBLISHPRESS_STATUSES_URL', trailingslashit(plugins_url('', __FILE__)));    // @todo: vendor lib
 


### PR DESCRIPTION
The Default Visibility and Lock Visibility features are ported over from Permissions, with improvements to the Gutenberg implementation.

The "Lock Publication" (prevent unpublishing) feature is new.