### PR TITLE
Rename PublishPress_Functions to package-specific class

### DIFF
--- a/Admin.php
+++ b/Admin.php
@@ -229,8 +229,8 @@ class Admin
                     }
                 }
             }
-        } elseif (\PublishPress_Functions::empty_REQUEST('post_status') 
-        || (\PublishPress_Functions::REQUEST_key('post_status') != $post->post_status)
+        } elseif (\PP_Statuses_Functions::empty_REQUEST('post_status') 
+        || (\PP_Statuses_Functions::REQUEST_key('post_status') != $post->post_status)
         ) {  // if filtering for this status, don't display caption in result rows
             $status_obj = (!empty($wp_post_statuses[$post->post_status])) ? $wp_post_statuses[$post->post_status] : false;
 
@@ -245,7 +245,7 @@ class Admin
     }
 
     function add_admin_styles() {
-        $plugin_page = \PublishPress_Functions::getPluginPage();
+        $plugin_page = \PP_Statuses_Functions::getPluginPage();
 
         if (0 === strpos($plugin_page, 'publishpress-statuses')) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
             wp_enqueue_style('publishpress-statuses-tooltips', PUBLISHPRESS_STATUSES_URL . '/common/css/_tooltip.css', [], PUBLISHPRESS_STATUSES_VERSION);
@@ -292,7 +292,7 @@ class Admin
             }
         }
 
-        $plugin_page = \PublishPress_Functions::getPluginPage();
+        $plugin_page = \PP_Statuses_Functions::getPluginPage();
 
         // Scripts and styles needed for Add Status, Edit Status, and possibly Statuses
         if (0 === strpos($plugin_page, 'publishpress-statuses')) {
@@ -324,7 +324,7 @@ class Admin
 
         // Scripts and styles for Statuses screen
         if ('publishpress-statuses' == $plugin_page
-        && in_array(\PublishPress_Functions::REQUEST_key('action'), ['', 'statuses'])
+        && in_array(\PP_Statuses_Functions::REQUEST_key('action'), ['', 'statuses'])
         ) {
             wp_enqueue_script('jquery-ui-core');
             wp_enqueue_script('jquery-ui-sortable');
@@ -380,7 +380,7 @@ class Admin
 
         // Custom javascript to modify the post status dropdown where it shows up
         if (self::is_post_management_page() && class_exists('PublishPress_Functions')) {
-            if (\PublishPress_Functions::isBlockEditorActive(['force' => \PublishPress_Statuses::instance()->options->force_editor_detection])) {
+            if (\PP_Statuses_Functions::isBlockEditorActive(['force' => \PublishPress_Statuses::instance()->options->force_editor_detection])) {
                 wp_enqueue_style(
                     'publishpress-custom_status-block',
                     PUBLISHPRESS_STATUSES_URL . 'common/css/custom-status-block-editor.css',
@@ -469,7 +469,7 @@ class Admin
         }
 
         // Disable the scripts for the post page if the plugin Visual Composer is enabled.
-        if ('frontend' === \PublishPress_Functions::GET_key('vcv-action')) {
+        if ('frontend' === \PP_Statuses_Functions::GET_key('vcv-action')) {
             return false;
         }
 
@@ -893,7 +893,7 @@ class Admin
             	// Ensure stases reload following import
                 wp_cache_delete('publishpress_status_positions', 'options');
 
-                if (('admin.php' == $pagenow) && \PublishPress_Functions::is_REQUEST('publishpress-statuses')) {
+                if (('admin.php' == $pagenow) && \PP_Statuses_Functions::is_REQUEST('publishpress-statuses')) {
                     \PublishPress_Statuses::instance(true);
                 }
             }

--- a/PostEdit.php
+++ b/PostEdit.php
@@ -7,7 +7,7 @@ namespace PublishPress_Statuses;
 class PostEdit
 {
     function __construct() {
-        if (!in_array(\PublishPress_Functions::findPostType(), ['forum', 'topic', 'reply'])) {
+        if (!in_array(\PP_Statuses_Functions::findPostType(), ['forum', 'topic', 'reply'])) {
             // Gutenberg scripts are only loaded if Gutenberg-specific actions fire.
             add_action('enqueue_block_editor_assets', [$this, 'actLoadGutenbergScripts']);
 
@@ -19,7 +19,7 @@ class PostEdit
 
                 add_action('admin_enqueue_scripts', function() {
                     // Load full set of Classic Editor scripts if Gutenberg is not detected, or if Classic Editor explicitly specified by plugin setting
-                    if (! \PublishPress_Functions::isBlockEditorActive(['force' => \PublishPress_Statuses::instance()->options->force_editor_detection])) {
+                    if (! \PP_Statuses_Functions::isBlockEditorActive(['force' => \PublishPress_Statuses::instance()->options->force_editor_detection])) {
                         require_once(__DIR__ . '/PostEditClassic.php');
                         $obj = new PostEditClassic();
                         $obj->post_admin_header();
@@ -32,7 +32,7 @@ class PostEdit
 
         global $pagenow;
 
-        $post_type = \PublishPress_Functions::findPostType();
+        $post_type = \PP_Statuses_Functions::findPostType();
 
         $options = \PublishPress_Statuses::instance()->options;
         $default_privacy = (is_object($options) && !empty($options->default_privacy) && !empty($options->default_privacy[$post_type])) ? $options->default_privacy[$post_type] : '';

--- a/PostEditGutenberg.php
+++ b/PostEditGutenberg.php
@@ -18,7 +18,7 @@ class PostEditGutenberg
             }
         }
 
-        if ($post_id = \PublishPress_Functions::getPostID()) {
+        if ($post_id = \PP_Statuses_Functions::getPostID()) {
             if (defined('PUBLISHPRESS_REVISIONS_VERSION') && !class_exists('PublishPress_Statuses\Revisions') && rvy_in_revision_workflow($post_id)) {
                 return;
             }
@@ -153,7 +153,7 @@ class PostEditGutenberg
     private function getStatuses($args = false, $only_basic_info = false)
     {
         global $post;
-        $post_type = \PublishPress_Functions::findPostType();
+        $post_type = \PP_Statuses_Functions::findPostType();
 
         if (!is_array($args)) {
             $args = ['moderation' => true];

--- a/PostEditGutenbergStatuses.php
+++ b/PostEditGutenbergStatuses.php
@@ -7,7 +7,7 @@ class PostEditGutenbergStatuses
 {
     public static function loadBlockEditorStatusGuidance() 
     {
-        if ($post_id = \PublishPress_Functions::getPostID()) {
+        if ($post_id = \PP_Statuses_Functions::getPostID()) {
             if (defined('PUBLISHPRESS_REVISIONS_VERSION') && !class_exists('PublishPress_Statuses\Revisions') && rvy_in_revision_workflow($post_id)) {
                 return;
             }
@@ -89,7 +89,7 @@ class PostEditGutenbergStatuses
             $next_status_obj = $current_status_obj;
         }
 
-        $post_type = \PublishPress_Functions::findPostType();
+        $post_type = \PP_Statuses_Functions::findPostType();
 
         $args['lockStatus'] = false;
 

--- a/PostsListing.php
+++ b/PostsListing.php
@@ -20,7 +20,7 @@ class PostsListing
         add_action('admin_print_footer_scripts', [$this, 'act_modify_inline_edit_ui']);
 
         add_action('plugins_loaded', function() {
-            add_filter('views_' . \PublishPress_Functions::findPostType(), [$this, 'flt_views_stati']);
+            add_filter('views_' . \PP_Statuses_Functions::findPostType(), [$this, 'flt_views_stati']);
         });
 
         add_action('the_post', [$this, 'act_log_displayed_posts']);
@@ -156,7 +156,7 @@ class PostsListing
 
     function flt_views_stati($views)
     {
-        $post_type = \PublishPress_Functions::findPostType();
+        $post_type = \PP_Statuses_Functions::findPostType();
         $type_stati = \PublishPress_Statuses::getPostStati(['show_in_admin_all_list' => true, 'post_type' => $post_type]);
 
         if (\PublishPress_Statuses::DisabledForPostType($post_type)) {
@@ -170,7 +170,7 @@ class PostsListing
 
         $total_posts = array_sum((array)$num_posts);
 
-        $class = !isset($views['mine']) && \PublishPress_Functions::empty_REQUEST('post_status', 'show_sticky') ? ' class="current"' : '';
+        $class = !isset($views['mine']) && \PP_Statuses_Functions::empty_REQUEST('post_status', 'show_sticky') ? ' class="current"' : '';
         $allposts = (strpos($views['all'], 'all_posts=1')) ? $allposts = '&all_posts=1' : '';
 
         $views['all'] = "<a href='edit.php?post_type=$post_type{$allposts}'$class>" 

--- a/PublishPress_Statuses.php
+++ b/PublishPress_Statuses.php
@@ -106,7 +106,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
     }
 
     private function load() {
-        $plugin_page = \PublishPress_Functions::getPluginPage();
+        $plugin_page = \PP_Statuses_Functions::getPluginPage();
 
         if (is_admin()) {
             // Methods for handling the actions of creating, making default, and deleting post stati
@@ -557,7 +557,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
     public function get_ajax_selectable_statuses()
     {
         if (!empty($_REQUEST['post_id'])) {
-            if (!wp_verify_nonce(\PublishPress_Functions::POST_key('pp_nonce'),'pp-custom-statuses-nonce')) {
+            if (!wp_verify_nonce(\PP_Statuses_Functions::POST_key('pp_nonce'),'pp-custom-statuses-nonce')) {
                 exit;
             }
 
@@ -610,9 +610,9 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
 
             $statuses = array_keys(\PublishPress_Statuses\Admin::get_selectable_statuses($post_id, $args));
 
-            \PublishPress_Functions::printAjaxResponse('success', '', $statuses, $params);
+            \PP_Statuses_Functions::printAjaxResponse('success', '', $statuses, $params);
         } else {
-            \PublishPress_Functions::printAjaxResponse('success', '', [], []);
+            \PP_Statuses_Functions::printAjaxResponse('success', '', [], []);
         }
 
         exit;
@@ -621,9 +621,9 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
     public function set_workflow_action($action) {
         global $current_user;
 
-        if ($post_id = \PublishPress_Functions::REQUEST_int('post_id')) {
-            if ($workflow_action = \PublishPress_Functions::REQUEST_key('workflow_action')) {
-                if (!wp_verify_nonce(\PublishPress_Functions::POST_key('pp_nonce'),'pp-custom-statuses-nonce')) {
+        if ($post_id = \PP_Statuses_Functions::REQUEST_int('post_id')) {
+            if ($workflow_action = \PP_Statuses_Functions::REQUEST_key('workflow_action')) {
+                if (!wp_verify_nonce(\PP_Statuses_Functions::POST_key('pp_nonce'),'pp-custom-statuses-nonce')) {
                     exit;
                 }
 
@@ -633,20 +633,20 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
 
                 update_user_meta($current_user->ID, "_pp_statuses_workflow_action_" . $post_id, sanitize_key($workflow_action));
 
-                \PublishPress_Functions::printAjaxResponse('success', '', [], []);
+                \PP_Statuses_Functions::printAjaxResponse('success', '', [], []);
             }
         }
     }
 
     public static function isStatusManagement() {
-        $plugin_page = \PublishPress_Functions::getPluginPage();
+        $plugin_page = \PP_Statuses_Functions::getPluginPage();
         
         return
             in_array($plugin_page, ['publishpress-statuses', 'pp-capabilities'])
             || (
                 isset($_SERVER['SCRIPT_NAME']) 
                 && false !== strpos(sanitize_text_field($_SERVER['SCRIPT_NAME']), 'admin-ajax.php') 
-                && \PublishPress_Functions::is_REQUEST('action', ['pp_update_status_positions', 'pp_statuses_toggle', 'pp_delete_custom_status'])
+                && \PP_Statuses_Functions::is_REQUEST('action', ['pp_update_status_positions', 'pp_statuses_toggle', 'pp_delete_custom_status'])
             );
     }
 
@@ -1302,7 +1302,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
     }
 
     public static function getCurrentPostType() {
-        return \PublishPress_Functions::getPostType();
+        return \PP_Statuses_Functions::getPostType();
     }
 
     public static function DisabledForPostType($post_type = null) {
@@ -1531,7 +1531,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
     {
         global $wp_post_statuses;
 
-        $plugin_page = \PublishPress_Functions::getPluginPage();
+        $plugin_page = \PP_Statuses_Functions::getPluginPage();
 
         if (!is_array($function_args)) {
             $function_args = [$function_args => $function_args];
@@ -2696,7 +2696,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
             $post_id = $post->ID;
         } else {
             if (!$post_id && !$skip_post_id_check) {
-                $post_id = \PublishPress_Functions::getPostID();
+                $post_id = \PP_Statuses_Functions::getPostID();
             }
 
             if ($post_id) {
@@ -2707,7 +2707,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
         }
 
         if (empty($post)) {
-            $post_type = (!empty($args['post_type'])) ? $args['post_type'] : \PublishPress_Functions::findPostType();
+            $post_type = (!empty($args['post_type'])) ? $args['post_type'] : \PP_Statuses_Functions::findPostType();
         } else {
             $post_type = $post->post_type;
         }
@@ -3222,7 +3222,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
         }
 
         $role_caps = [];
-        $roles = \PublishPress_Functions::getRoles(true);
+        $roles = \PP_Statuses_Functions::getRoles(true);
 
         foreach (array_keys($roles) as $role_name) {
             if ($role = get_role($role_name)) {
@@ -3347,7 +3347,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
 
         if ($orig_status != $post_status) {
             if (!$post_id = \PublishPress_Statuses::instance()->getCurrentSanitizePostID()) {
-                $post_id = \PublishPress_Functions::getPostID();
+                $post_id = \PP_Statuses_Functions::getPostID();
             }
 
             if ($post_id) {
@@ -3379,20 +3379,20 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
         if (!empty($done)) return $post_status;  // Important: if other plugin code inserts additional posts in response, don't filter those
         $done = true;
 
-        if ($post_id = \PublishPress_Functions::getPostID()) {
+        if ($post_id = \PP_Statuses_Functions::getPostID()) {
             $_post = get_post($post_id);
         } else {
             $_post = false;
         }
 
-        if (!\PublishPress_Functions::empty_POST('post_password')) {
+        if (!\PP_Statuses_Functions::empty_POST('post_password')) {
             return $post_status;
         }
 
         if (!empty($_post) && !empty($_post->post_type)) {
             $post_type = $_post->post_type;
         } else {
-            if (!$post_type = \PublishPress_Functions::findPostType()) {
+            if (!$post_type = \PP_Statuses_Functions::findPostType()) {
                 return $post_status;
             }
         }
@@ -3421,7 +3421,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
                 $default_privacy = (is_object($options) && !empty($options->default_privacy) && !empty($options->default_privacy[$post_type])) ? $options->default_privacy[$post_type] : 'publish';
         
                 if (get_post_status_object($default_privacy)) {
-                    if ($post_id = \PublishPress_Functions::getPostID()) {
+                    if ($post_id = \PP_Statuses_Functions::getPostID()) {
                         $_post = get_post($post_id);
                     }
     
@@ -3480,7 +3480,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
             $post_id = $args['post_id'];
         } else {
             if (!$post_id = \PublishPress_Statuses::instance()->useSanitizePostID()) {
-                $post_id = \PublishPress_Functions::getPostID();
+                $post_id = \PP_Statuses_Functions::getPostID();
             }
         }
 
@@ -3512,7 +3512,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
             $save_as_pending = true;
         }
 
-        $post_type = ($_post) ? $_post->post_type : \PublishPress_Functions::findPostType();
+        $post_type = ($_post) ? $_post->post_type : \PP_Statuses_Functions::findPostType();
 
         if (!in_array($post_type, \PublishPress_Statuses::getEnabledPostTypes())) {
             return $post_status;
@@ -3531,18 +3531,18 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
             $stored_status_obj = get_post_status_object($stored_status);
         }
 
-        if ($doing_rest = defined('REST_REQUEST') && (!\PublishPress_Functions::empty_REQUEST('meta-box-loader') || $this->doing_rest))  {
+        if ($doing_rest = defined('REST_REQUEST') && (!\PP_Statuses_Functions::empty_REQUEST('meta-box-loader') || $this->doing_rest))  {
             $rest = \PublishPress_Statuses\REST::instance();
         }
 
         if ($doing_rest && !empty($rest->params['pp_status_selection'])) {
             $_post_status = $rest->params['pp_status_selection'];
         } else {
-            if (('_public' === \PublishPress_Functions::REQUEST_key('post_status')) && !$doing_rest) {
+            if (('_public' === \PP_Statuses_Functions::REQUEST_key('post_status')) && !$doing_rest) {
                 $_post_status = 'public';
                 $classic_explicit_publish = true;
             } else {
-                $_post_status = \PublishPress_Functions::POST_key('post_status');
+                $_post_status = \PP_Statuses_Functions::POST_key('post_status');
             }
         }
 
@@ -3557,7 +3557,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
 
         $this->logLastMainSection($_post_status, $post_id);
 
-        if (\PublishPress_Functions::REQUEST_key('save') && !$doing_rest
+        if (\PP_Statuses_Functions::REQUEST_key('save') && !$doing_rest
         || ($doing_rest && !empty($rest->params['pp_status_selection']))
         ) {
             return $_post_status;
@@ -3631,7 +3631,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
                     $selected_status_dropdown = 'pending';
                 }
 
-                $post_type = ($post_id) ? '' : \PublishPress_Functions::findPostType();
+                $post_type = ($post_id) ? '' : \PP_Statuses_Functions::findPostType();
 
                 switch ($workflow_action) {
                     case 'specified':
@@ -3652,7 +3652,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
 
                     default:
                         if ((($doing_rest && !empty($rest->params['pp_statuses_selecting_workflow']))
-                        || !\PublishPress_Functions::empty_POST('publish'))
+                        || !\PP_Statuses_Functions::empty_POST('publish'))
                         || ($is_revision && !empty($_POST) && !empty($_POST['originalaction']) && ('editpost' == $_POST['originalaction']))     // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
                         ) {
                             if (empty($save_as_pending) 
@@ -3796,7 +3796,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
         $default_action = '';
         $post_status = '';
 
-        if ($post_id = \PublishPress_Functions::getPostID()) {
+        if ($post_id = \PP_Statuses_Functions::getPostID()) {
             if ($post_status = get_post_field('post_status', $post_id)) {
                 if ($status_obj = get_post_status_object($post_status)) {
                     if (in_array($post_status, ['publish', 'private', 'future']) || !empty($stored_status_obj->public) || !empty($stored_status_obj->private)) {
@@ -3807,7 +3807,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
 
             $post_type = get_post_field('post_type', $post_id);
         } else {
-            $post_type = \PublishPress_Functions::findPostType();
+            $post_type = \PP_Statuses_Functions::findPostType();
         }
 
         if (!$default_action) {
@@ -3832,7 +3832,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
     public static function getStatusSelection( $object ) {
         $status_selection = '';
 
-        if ($post_id = \PublishPress_Functions::getPostID()) {
+        if ($post_id = \PP_Statuses_Functions::getPostID()) {
             if ($post_status = get_post_field('post_status', $post_id)) {
                 if (get_post_status_object($post_status)) {
                     $status_selection = $post_status;

--- a/StatusAddNewUI.php
+++ b/StatusAddNewUI.php
@@ -15,8 +15,8 @@ method='post' id='addstatus' name='addstatus'>
     <input type="hidden" name="action" value="add-status" />
 
     <?php 
-    if (!$_taxonomy = \PublishPress_Functions::REQUEST_key('taxonomy')) {
-        if ('visibility' == \PublishPress_Functions::REQUEST_key('status_type')) {
+    if (!$_taxonomy = \PP_Statuses_Functions::REQUEST_key('taxonomy')) {
+        if ('visibility' == \PP_Statuses_Functions::REQUEST_key('status_type')) {
             $_taxonomy = 'post_visibility_pp';
         }
     }

--- a/StatusEditUI.php
+++ b/StatusEditUI.php
@@ -7,7 +7,7 @@ class StatusEditUI
     public static function display() {
 
         // Check whether the term exists
-        $name = \PublishPress_Functions::REQUEST_key('name');
+        $name = \PP_Statuses_Functions::REQUEST_key('name');
 
         if (!$status = \PublishPress_Statuses::getStatusBy('id', $name)) {
             echo '<div class="error"><p>' . esc_html(\PublishPress_Statuses::instance()->messages['status-missing']) . '</p></div>';
@@ -16,7 +16,7 @@ class StatusEditUI
 
         $url_args = ['action' => 'statuses'];
 
-        if ($status_type = \PublishPress_Functions::REQUEST_key('status_type')) {
+        if ($status_type = \PP_Statuses_Functions::REQUEST_key('status_type')) {
             $url_args['status_type'] = $status_type;
         }
 
@@ -88,7 +88,7 @@ class StatusEditUI
 
         $tabs = apply_filters('publishpress_statuses_edit_status_tabs', $tabs, $status->name);
 
-        $pp_tab = (!\PublishPress_Functions::empty_REQUEST('pp_tab')) ? \PublishPress_Functions::REQUEST_key('pp_tab') : 'name';
+        $pp_tab = (!\PP_Statuses_Functions::empty_REQUEST('pp_tab')) ? \PP_Statuses_Functions::REQUEST_key('pp_tab') : 'name';
 
         $default_tab = apply_filters('presspermit_edit_status_default_tab', $pp_tab);
 
@@ -205,8 +205,8 @@ class StatusEditUI
                 <input type="hidden" name="action" value="edit-status" />
                 <input type="hidden" name="pp_tab" value="<?php echo '#pp-' . esc_attr($default_tab);?>" />
                 <?php
-                if (!\PublishPress_Functions::empty_REQUEST('return_module')) :?>
-                    <input type="hidden" name="return_module" value="<?php echo esc_attr(\PublishPress_Functions::REQUEST_key('return_module'));?>" />
+                if (!\PP_Statuses_Functions::empty_REQUEST('return_module')) :?>
+                    <input type="hidden" name="return_module" value="<?php echo esc_attr(\PP_Statuses_Functions::REQUEST_key('return_module'));?>" />
                 <?php endif;
 
                 submit_button(__('Update Status', 'publishpress-statuses'), 'primary pp-statuses', 'submit', false); ?>
@@ -391,7 +391,7 @@ class StatusEditUI
 
         switch ($tab) {
             case 'roles' :
-                $roles = \PublishPress_Functions::getRoles(true);
+                $roles = \PP_Statuses_Functions::getRoles(true);
                 ?>
                 <tr class="form-field">
                     <th><label for="status_assign"><?php esc_html_e('Status Availability', 'publishpress-statuses') ?></label>
@@ -403,7 +403,7 @@ class StatusEditUI
 
                     <td class="set-status-roles">
                         <?php foreach($roles as $role_name => $role_label):
-                            if (\PublishPress_Functions::isEditableRole($role_name)) :
+                            if (\PP_Statuses_Functions::isEditableRole($role_name)) :
                                 $role = get_role($role_name);
                                 $cap_name = str_replace('-', '_', "status_change_{$status->name}");
 

--- a/StatusHandler.php
+++ b/StatusHandler.php
@@ -161,7 +161,7 @@ class StatusHandler {
 
         $redirect_args = ['action' => 'edit-status', 'name' => $status_name, 'message' => 'status-added'];
 
-        if ($status_type = \PublishPress_Functions::REQUEST_key('status_type')) {
+        if ($status_type = \PP_Statuses_Functions::REQUEST_key('status_type')) {
             $redirect_args['status_type'] = $status_type;
         }
 
@@ -356,7 +356,7 @@ class StatusHandler {
                 $role_name = sanitize_key($role_name);
                 $set_val = boolval($set_val);
 
-                if (!\PublishPress_Functions::isEditableRole($role_name)) {
+                if (!\PP_Statuses_Functions::isEditableRole($role_name)) {
                     continue;
                 }
 
@@ -382,10 +382,10 @@ class StatusHandler {
 
         $status_obj = get_post_status_object($name);
 
-        if (!\PublishPress_Functions::empty_REQUEST('return_module')) {
+        if (!\PP_Statuses_Functions::empty_REQUEST('return_module')) {
             $arr = ['message' => 'status-updated'];
             $arr['page'] = 'pp-modules-settings';
-            $arr['settings_module'] = \PublishPress_Functions::REQUEST_key('return_module');
+            $arr['settings_module'] = \PP_Statuses_Functions::REQUEST_key('return_module');
 
             $redirect_url = \PublishPress_Statuses::getLink($arr);
         } else {
@@ -648,7 +648,7 @@ class StatusHandler {
     public static function handleAjaxDeleteStatus() {
         check_ajax_referer('custom-status-sortable');
 
-        if ($status_name = \PublishPress_Functions::REQUEST_key('delete_status')) {
+        if ($status_name = \PP_Statuses_Functions::REQUEST_key('delete_status')) {
             if (!current_user_can('manage_options') && !current_user_can('pp_manage_statuses')) {
                 self::printAjaxResponse('error', esc_html(\PublishPress_Statuses::__wp('Sorry, you are not allowed to access this page.')));
             }
@@ -760,7 +760,7 @@ class StatusHandler {
      */
     public static function printAjaxResponse($status, $message = '', $data = null)
     {
-        \PublishPress_Functions::printAjaxResponse($status, $message, $data);
+        \PP_Statuses_Functions::printAjaxResponse($status, $message, $data);
     }
 
     /**
@@ -795,7 +795,7 @@ class StatusHandler {
 
     public static function settings_validate_and_save()
     {
-        if (!wp_verify_nonce(\PublishPress_Functions::POST_key('_wpnonce'), 'edit-publishpress-settings')
+        if (!wp_verify_nonce(\PP_Statuses_Functions::POST_key('_wpnonce'), 'edit-publishpress-settings')
         || !current_user_can('manage_options')
         ) {
             wp_die(esc_html__('Cheatin&#8217; uh?'));
@@ -863,60 +863,60 @@ class StatusHandler {
         update_option('publishpress_custom_status_options', (object) $new_options);
         
         // Import / Backup Operations
-        if (\PublishPress_Functions::is_POST('publishpress_statuses_import_operation', 'do_status_control_import')) {
+        if (\PP_Statuses_Functions::is_POST('publishpress_statuses_import_operation', 'do_status_control_import')) {
             update_option('pp_statuses_force_status_control_import', true);
             update_option('pp_statuses_force_planner_import', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_import_operation', 'do_planner_import')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_import_operation', 'do_planner_import')) {
             update_option('pp_statuses_force_planner_import', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_import_operation', 'do_planner_import_only')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_import_operation', 'do_planner_import_only')) {
             update_option('pp_statuses_skip_status_control_import', true);
             update_option('pp_statuses_force_planner_import', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'backup_status_properties')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'backup_status_properties')) {
             update_option('pp_statuses_set_backup_props', true);
             
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_colors')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_colors')) {
             update_option('pp_statuses_restore_backup_colors', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_icons')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_icons')) {
             update_option('pp_statuses_restore_backup_icons', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_labels')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_labels')) {
             update_option('pp_statuses_restore_backup_labels', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_post_types')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_post_types')) {
             update_option('pp_statuses_restore_backup_post_types', true);
         
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_colors_auto')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_colors_auto')) {
             update_option('pp_statuses_restore_autobackup_colors', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_icons_auto')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_icons_auto')) {
             update_option('pp_statuses_restore_autobackup_icons', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_labels_auto')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_labels_auto')) {
             update_option('pp_statuses_restore_autobackup_labels', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_post_types_auto')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'restore_status_post_types_auto')) {
             update_option('pp_statuses_restore_autobackup_post_types', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_colors')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_colors')) {
             update_option('pp_statuses_default_colors', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_icons')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_icons')) {
             update_option('pp_statuses_default_icons', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_labels')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_labels')) {
             update_option('pp_statuses_default_labels', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_post_types')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_post_types')) {
             update_option('pp_statuses_default_post_types', true);
         
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_colors_planner')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_colors_planner')) {
             update_option('pp_statuses_default_planner_colors', true);
 
-        } elseif (\PublishPress_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_icons_planner')) {
+        } elseif (\PP_Statuses_Functions::is_POST('publishpress_statuses_backup_operation', 'default_status_icons_planner')) {
             update_option('pp_statuses_default_planner_icons', true);
         }
 

--- a/StatusListTable.php
+++ b/StatusListTable.php
@@ -145,7 +145,7 @@ class StatusListTable extends \WP_List_Table
 
 <div class="is-dismissible notice notice-success pp-float-notice" style="clear:both;display:none;"><p></p></div>
 
-<?php if (!defined('PUBLISHPRESS_STATUSES_PRO_VERSION') && ('revision' == \PublishPress_Functions::REQUEST_key('status_type'))):?>
+<?php if (!defined('PUBLISHPRESS_STATUSES_PRO_VERSION') && ('revision' == \PP_Statuses_Functions::REQUEST_key('status_type'))):?>
     <div id="pp-statuses-promo">
     
     <!-- CTA Section -->
@@ -307,7 +307,7 @@ class StatusListTable extends \WP_List_Table
         $class = (!empty($args['class'])) ? $args['class'] : '';
         $label = (!empty($args['label'])) ? $args['label'] : $key;
 
-        if (($key == '_pre-publish-alternate') && (\PublishPress_Functions::empty_REQUEST('status_type') || 'moderation' == \PublishPress_Functions::REQUEST_key('status_type'))) :?>
+        if (($key == '_pre-publish-alternate') && (\PP_Statuses_Functions::empty_REQUEST('status_type') || 'moderation' == \PP_Statuses_Functions::REQUEST_key('status_type'))) :?>
             <li class="ui-sortable-placeholder moderation-status ui-temp-placeholder" style="height: 50px;">
             <div class="row tpl-default">
                 <div class="child-toggle" style="padding-left: 0">
@@ -324,7 +324,7 @@ class StatusListTable extends \WP_List_Table
         <?php endif;
 
 		do_action('publishpress_statuses_table_list', $key, $args);
-        if (!$status_type = \PublishPress_Functions::REQUEST_key('status_type')) {
+        if (!$status_type = \PP_Statuses_Functions::REQUEST_key('status_type')) {
             $status_type = 'moderation';
         }
 
@@ -377,7 +377,7 @@ do_action('publishpress_statuses_table_row', $key, []);
         <?php
         switch ($key) {
             case '_pre-publish-alternate':
-                if (\PublishPress_Functions::empty_REQUEST('status_type') || 'moderation' == \PublishPress_Functions::REQUEST_key('status_type')) :?>
+                if (\PP_Statuses_Functions::empty_REQUEST('status_type') || 'moderation' == \PP_Statuses_Functions::REQUEST_key('status_type')) :?>
                 <li class="ui-sortable-placeholder alternate-moderation-status ui-temp-placeholder" style="height: 50px;">
                 <div class="row tpl-default">
                     <div class="child-toggle" style="padding-left: 0">
@@ -446,7 +446,7 @@ do_action('publishpress_statuses_table_row', $key, []);
         endif;?>
         <?php
 
-        if (!$status_type = \PublishPress_Functions::REQUEST_key('status_type')) {
+        if (!$status_type = \PP_Statuses_Functions::REQUEST_key('status_type')) {
             $status_type = 'moderation';
         }
 

--- a/StatusesUI.php
+++ b/StatusesUI.php
@@ -25,7 +25,7 @@ class StatusesUI {
     }
 
     private function load() {
-        $plugin_page = \PublishPress_Functions::getPluginPage();
+        $plugin_page = \PP_Statuses_Functions::getPluginPage();
 
         add_filter('presspermit_edit_status_default_tab', [$this, 'fltEditStatusDefaultTab']);
 
@@ -34,7 +34,7 @@ class StatusesUI {
             add_action('admin_init', [$this, 'register_settings']);
         }
 
-        if ('publishpress_custom_status_options' === \PublishPress_Functions::POST_key('option_page')) { 
+        if ('publishpress_custom_status_options' === \PP_Statuses_Functions::POST_key('option_page')) { 
             add_action('admin_init', function() {
                 $this->handle_settings();
             });
@@ -44,7 +44,7 @@ class StatusesUI {
 
         // @todo: REST
         if ((0 === strpos($plugin_page, 'publishpress-statuses'))
-        && !\PublishPress_Functions::empty_POST('submit')
+        && !\PP_Statuses_Functions::empty_POST('submit')
         ) {
             add_action('init', function() {
                 $this->handle_add_custom_status();
@@ -56,8 +56,8 @@ class StatusesUI {
         $title = '';
 
         if (('publishpress-statuses' === $plugin_page) 
-        && ('edit-status' === \PublishPress_Functions::REQUEST_key('action'))) {
-            $status_name = \PublishPress_Functions::REQUEST_key('name');
+        && ('edit-status' === \PP_Statuses_Functions::REQUEST_key('action'))) {
+            $status_name = \PP_Statuses_Functions::REQUEST_key('name');
 
             if ($status_obj = get_post_status_object($status_name)) {
                 // translators: %s is the status label
@@ -68,8 +68,8 @@ class StatusesUI {
             }
 
         } elseif ('publishpress-statuses-add-new' === $plugin_page) {
-            if (!\PublishPress_Functions::empty_REQUEST('taxonomy')) {
-                if ($tx = get_taxonomy(\PublishPress_Functions::REQUEST_key('taxonomy'))) {
+            if (!\PP_Statuses_Functions::empty_REQUEST('taxonomy')) {
+                if ($tx = get_taxonomy(\PP_Statuses_Functions::REQUEST_key('taxonomy'))) {
                     $title = sprintf(
                         // translators: %s is status type: "Workflow", "Visibility", "Revision", etc.
                         __('Add %s Status', 'publishpress-statuses'),
@@ -91,7 +91,7 @@ class StatusesUI {
             $title = __('Post Statuses', 'publishpress-statuses');
             $custom_html_title = __('Statuses', 'publishpress-statuses');
             
-            if ($status_type = \PublishPress_Functions::REQUEST_key('status_type')) { // @todo: implement hook in Permissions
+            if ($status_type = \PP_Statuses_Functions::REQUEST_key('status_type')) { // @todo: implement hook in Permissions
                 $_title = $title;
                 
                 if ('visibility' == $status_type) {
@@ -128,8 +128,8 @@ class StatusesUI {
      */
     public function handle_add_custom_status()
     {
-        if (('add-status' === \PublishPress_Functions::POST_key('action'))
-        && \PublishPress_Functions::empty_REQUEST('settings_module')) {
+        if (('add-status' === \PP_Statuses_Functions::POST_key('action'))
+        && \PP_Statuses_Functions::empty_REQUEST('settings_module')) {
             require_once(__DIR__ . '/StatusHandler.php');
             \PublishPress_Statuses\StatusHandler::handleAddCustomStatus();
         }
@@ -140,8 +140,8 @@ class StatusesUI {
      */
     public function handle_edit_custom_status()
     {
-        if (('edit-status' === \PublishPress_Functions::POST_key('action')) 
-        && \PublishPress_Functions::empty_REQUEST('settings_module')) {
+        if (('edit-status' === \PP_Statuses_Functions::POST_key('action')) 
+        && \PP_Statuses_Functions::empty_REQUEST('settings_module')) {
             require_once(__DIR__ . '/StatusHandler.php');
             \PublishPress_Statuses\StatusHandler::handleEditCustomStatus();
         }
@@ -154,8 +154,8 @@ class StatusesUI {
      */
     public function handle_delete_custom_status()
     {
-        if ('delete-status' === (\PublishPress_Functions::POST_key('action')) 
-        && \PublishPress_Functions::empty_REQUEST('settings_module')) {
+        if ('delete-status' === (\PP_Statuses_Functions::POST_key('action')) 
+        && \PP_Statuses_Functions::empty_REQUEST('settings_module')) {
             require_once(__DIR__ . '/StatusHandler.php');
             \PublishPress_Statuses\StatusHandler::handleDeleteCustomStatus();
         }
@@ -166,8 +166,8 @@ class StatusesUI {
      */
     public function handle_settings()
     {
-        if (!\PublishPress_Functions::empty_POST('action')
-        && ('publishpress_custom_status_options' === \PublishPress_Functions::POST_key('option_page'))
+        if (!\PP_Statuses_Functions::empty_POST('action')
+        && ('publishpress_custom_status_options' === \PP_Statuses_Functions::POST_key('option_page'))
         ) {
             require_once(__DIR__ . '/StatusHandler.php');
             \PublishPress_Statuses\StatusHandler::settings_validate_and_save();
@@ -994,7 +994,7 @@ class StatusesUI {
     }
 
     public function fltEditStatusDefaultTab($default_tab) {
-        if (!$default_tab = \PublishPress_Functions::REQUEST_key('pp_tab')) {
+        if (!$default_tab = \PP_Statuses_Functions::REQUEST_key('pp_tab')) {
             $default_tab = 'name';
         }
 
@@ -1006,14 +1006,14 @@ class StatusesUI {
      */
     public function render_admin_page()
     {
-        $plugin_page = \PublishPress_Functions::getPluginPage();
+        $plugin_page = \PP_Statuses_Functions::getPluginPage();
 
-        $action = \PublishPress_Functions::GET_key('action');
+        $action = \PP_Statuses_Functions::GET_key('action');
         $enable_left_col = false;
 
         /** Edit Status screen **/
-        if (('publishpress-statuses' === $plugin_page) && ('edit-status' == $action) && !\PublishPress_Functions::empty_REQUEST('name')) {
-            $status_name = \PublishPress_Functions::REQUEST_key('name');
+        if (('publishpress-statuses' === $plugin_page) && ('edit-status' == $action) && !\PP_Statuses_Functions::empty_REQUEST('name')) {
+            $status_name = \PP_Statuses_Functions::REQUEST_key('name');
             
             $status_obj = \PublishPress_Statuses::getStatusBy('id', $status_name);
 
@@ -1038,7 +1038,7 @@ class StatusesUI {
         /** Statuses screen **/
         } elseif (('publishpress-statuses' === $plugin_page) && (!$action || ('statuses' == $action))) {
             add_action('publishpress_header_button', function() {
-                $status_type = \PublishPress_Functions::REQUEST_key('status_type');
+                $status_type = \PP_Statuses_Functions::REQUEST_key('status_type');
                 
                 $args = [
                     'action' => 'add-new', 
@@ -1069,7 +1069,7 @@ class StatusesUI {
                 }
             });
 
-            $status_type = \PublishPress_Functions::REQUEST_key('status_type');
+            $status_type = \PP_Statuses_Functions::REQUEST_key('status_type');
 
             \PublishPress\ModuleAdminUI_Base::instance()->default_header();
 
@@ -1111,7 +1111,7 @@ class StatusesUI {
             ?>
             <div class='nav-tab-wrapper'>
             <a href="<?php
-                if (!$status_type = \PublishPress_Functions::REQUEST_key('status_type')) {
+                if (!$status_type = \PP_Statuses_Functions::REQUEST_key('status_type')) {
                     $status_type = 'moderation';
                 }
 
@@ -1188,7 +1188,7 @@ class StatusesUI {
         <?php 
         /** Add New Status **/
         } elseif (isset($plugin_page) && ('publishpress-statuses-add-new' === $plugin_page)) {
-            $status_type = \PublishPress_Functions::REQUEST_key('status_type');
+            $status_type = \PP_Statuses_Functions::REQUEST_key('status_type');
 
 			if (('visibility' == $status_type) && ! defined('PRESSPERMIT_STATUSES_VERSION')) {
                 return;

--- a/Workarounds.php
+++ b/Workarounds.php
@@ -123,13 +123,13 @@ class Workarounds {
         }
 
         //Are we overriding the permalink? Don't do anything
-        if ('sample-permalink' === \PublishPress_Functions::POST_key('action')) {
+        if ('sample-permalink' === \PP_Statuses_Functions::POST_key('action')) {
             return $permalink;
         }
 
         //Are we previewing the post from the normal post screen?
         if (($pagenow == 'post.php' || $pagenow == 'post-new.php')
-        && !\PublishPress_Functions::is_POST('wp-preview')) {
+        && !\PP_Statuses_Functions::is_POST('wp-preview')) {
             return $permalink;
         }
 
@@ -178,7 +178,7 @@ class Workarounds {
         }
 
         //Are we overriding the permalink? Don't do anything
-        if ('sample-permalink' === \PublishPress_Functions::POST_key('action')) {
+        if ('sample-permalink' === \PP_Statuses_Functions::POST_key('action')) {
             return $permalink;
         }
 

--- a/includes-core/Core.php
+++ b/includes-core/Core.php
@@ -31,6 +31,6 @@ class Core {
     }
 
     public function shouldDisplayBanner() {
-        return \PublishPress_Functions::getPluginPage();
+        return \PP_Statuses_Functions::getPluginPage();
     }
 }

--- a/lib/PublishPress_Functions.php
+++ b/lib/PublishPress_Functions.php
@@ -1,10 +1,10 @@
 <?php
-if (!class_exists('PublishPress_Functions')) {
+if (!class_exists('PP_Statuses_Functions')) {
 
 /**
  * PublishPress_Functions
  */
-class PublishPress_Functions 
+class PP_Statuses_Functions 
 {
 
     /**

--- a/lib/publishpress-module/ModuleAdminUI_Base.php
+++ b/lib/publishpress-module/ModuleAdminUI_Base.php
@@ -30,7 +30,7 @@ class ModuleAdminUI_Base {
         $display_messages = [];
 
         // If there's been a message, let's display it
-        if (!$message = \PublishPress_Functions::REQUEST_key('message')) {
+        if (!$message = \PP_Statuses_Functions::REQUEST_key('message')) {
             $message = false;
         }
 


### PR DESCRIPTION
This is needed in the short term to ensure changes and additions made to the class functions are applied. In the future, these functions could be implemented as a shared library with version control.