### PR TITLE
Hide Deferred, Needs Work, Rejected statuses from Statuses admin table if status dropdown disabled

### DIFF
--- a/StatusListTable.php
+++ b/StatusListTable.php
@@ -559,6 +559,11 @@ do_action('publishpress_statuses_table_row', $key, []);
         ) {
             $class .= ' section-row';
         }
+
+        // Deferred, Needs Work and Rejected statuses require an Alternate Workflow selection UI
+        if (!empty($options->hide_manual_status_selectors) && in_array($item->name, ['deferred', 'needs-work', 'rejected'])) {
+            $hidden = true;
+        }
     
     	$hidden = apply_filters('publishpress_statuses_table_alternate_row_hidden', $hidden, $item, $status_type);
     	


### PR DESCRIPTION
These statuses require an alternate workflow UI. It does not make sense for them to be part of a linear workflow that every post passes through.