### PR TITLE
Ensure desired new status ordering regardless of which statuses have a custom order stored

### DIFF
--- a/PublishPress_Statuses.php
+++ b/PublishPress_Statuses.php
@@ -228,6 +228,7 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
             'label_storage' => '',
             'pending_status_regulation' => '',
             'auto_import' => 1,
+            'new_statuses_main_workflow' => 1,
 
             'custom_privacy_edit_caps' => defined('PPS_CUSTOM_PRIVACY_EDIT_CAPS') ? PPS_CUSTOM_PRIVACY_EDIT_CAPS : 0,
             'quick_edit_custom_privacy_dropdown' => 1,
@@ -1712,6 +1713,8 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
             }
         }
 
+        asort($stored_status_positions);
+
         // Make sure Revision statuses are not improperly disabled
         if ($positions && !empty($stored_status_positions)) {
             foreach (array_keys($stored_status_positions) as $status_name) {
@@ -1898,7 +1901,16 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
         if (!empty($did_status_maint)) {
             do_action('publishpress_statuses_maintenance_done');
         }
+
+        if (!empty(\PublishPress_Statuses::instance()->options->new_statuses_main_workflow)) {
+            $statuses_defaulted_to_main = (array) get_option('publishpress_statuses_defaulted_to_main', []);
+        } else {
+            $statuses_defaulted_to_main = [];
+        }
         
+        $default_positions = [];
+        $default_main_positions = [];
+
         // restore previously merged status positions (@todo: restore any other properties?)
         foreach ($all_statuses as $status_name => $status) {
             if (isset($stored_status_positions[$status_name])) {
@@ -1936,17 +1948,37 @@ class PublishPress_Statuses extends \PublishPress\PPP_Module_Base
                 } else {
                     $taxonomy = (!empty($status->taxonomy)) ? $status->taxonomy : 'post_status';
 
-                    if (!isset($default_positions[$taxonomy])) {
-                        $default_positions[$taxonomy] = apply_filters(
-                            'publishpress_statuses_default_position',
-                            $all_statuses['_pre-publish-alternate']->position,
-                            $taxonomy,
-                            $all_statuses
-                        );
-                    }
+                    if (!empty($statuses_defaulted_to_main[$status_name]) || !empty($all_statuses[$status_name]->pp_builtin)) {
+                        if (!isset($default_main_positions[$taxonomy])) {
+                            $set_pos = $all_statuses['_pre-publish-alternate']->position - 1;
 
-                    $all_statuses[$status_name]->position = $default_positions[$taxonomy];
-                    $stored_status_positions[$status_name] = $default_positions[$taxonomy];
+                            $default_main_positions[$taxonomy] = apply_filters(
+                                'publishpress_statuses_default_main_position',
+                                $set_pos,
+                                $taxonomy,
+                                $all_statuses
+                            );
+                        }
+
+                        $all_statuses[$status_name]->position = $default_main_positions[$taxonomy];
+                        $stored_status_positions[$status_name] = $default_main_positions[$taxonomy];
+                    } else {
+                        $all_statuses['_pre-publish-alternate']->position;
+
+                        if (!isset($default_positions[$taxonomy])) {
+                            $set_pos = $all_statuses['_pre-publish-alternate']->position;
+    
+                            $default_positions[$taxonomy] = apply_filters(
+                                'publishpress_statuses_default_position',
+                                $set_pos,
+                                $taxonomy,
+                                $all_statuses
+                            );
+                        }
+
+                        $all_statuses[$status_name]->position = $default_positions[$taxonomy];
+                        $stored_status_positions[$status_name] = $default_positions[$taxonomy];
+                    }
                 }
             }
 

--- a/StatusHandler.php
+++ b/StatusHandler.php
@@ -165,15 +165,36 @@ class StatusHandler {
             $redirect_args['status_type'] = $status_type;
         }
 
-        if ($status_positions = get_option('publishpress_status_positions')) {
-            $first_statuses = (in_array('draft-revision', $status_positions)) ? ['draft', 'draft-revision', $status_name] : ['draft', $status_name];
-            
-            $status_positions = array_merge(
-                $first_statuses,
-                array_diff($status_positions, $first_statuses)
-            );
-
-            update_option('publishpress_status_positions', $status_positions);
+        if (!empty(\PublishPress_Statuses::instance()->options->new_statuses_main_workflow)) {
+            $defaulted_to_main = (array) get_option('publishpress_statuses_defaulted_to_main', []);
+            $defaulted_to_main[$status_name] = true;
+            update_option('publishpress_statuses_defaulted_to_main', $defaulted_to_main);
+        
+            if ($status_positions = get_option('publishpress_status_positions')) {
+                $status_positions = array_values($status_positions);
+    
+                if ('post_status' == $taxonomy) {
+                    if ($alternate_pos = array_search('_pre-publish-alternate', $status_positions)) {
+                        $status_positions = array_merge(
+                            array_slice($status_positions, 0, $alternate_pos - 1),
+                            [$status_name],
+                            array_slice($status_positions, $alternate_pos)
+                        );
+    
+                        update_option('publishpress_status_positions', $status_positions);
+                    }
+                } elseif ('pp_revision_status' == $taxonomy) {
+                    if ($alternate_pos) {
+                        $status_positions = array_merge(
+                            array_slice($status_positions, 0, $alternate_pos - 1),
+                            [$status_name],
+                            array_slice($status_positions, $alternate_pos)
+                        );
+    
+                        update_option('publishpress_status_positions', $status_positions);
+                    }
+                }
+            }
         }
 
         // Redirect if successful

--- a/StatusesUI.php
+++ b/StatusesUI.php
@@ -273,9 +273,9 @@ class StatusesUI {
             );
 
             add_settings_field(
-                'status_dropdown_show_current_branch_only',
-                '',
-                [$this, 'settings_status_dropdown_show_current_branch_only_option'],
+                'hide_manual_status_selectors',
+                __('New Status Position:', 'publishpress-statuses'),
+                [$this, 'settings_new_statuses_main_workflow_option'],
                 $group_name,
                 $group_name . '_general',
                 ['class' => 'pp-settings-workflow']
@@ -542,14 +542,9 @@ class StatusesUI {
         </script>
 
         <?php
-    }
-
-    public function settings_status_dropdown_show_current_branch_only_option() {
-        $module = \PublishPress_Statuses::instance();
-
         $status_dropdown_disabled = $module->options->hide_manual_status_selectors;
 
-        echo '<div class="c-input-group status_dropdown_current_branch_only" ';
+        echo '<br><br><div class="c-input-group status_dropdown_current_branch_only" ';
         if ($status_dropdown_disabled) echo 'style="display: none"'; 
         echo ' >';
 
@@ -588,6 +583,31 @@ class StatusesUI {
         </script>
 
         <?php
+        echo '</div>';
+    }
+
+    public function settings_new_statuses_main_workflow_option() {
+        $module = \PublishPress_Statuses::instance();
+        
+        echo '<div class="c-input-group">';
+
+        echo sprintf(
+            '<input type="hidden" name="%s" value="0" />',
+            esc_attr(\PublishPress_Statuses::SETTINGS_SLUG) . '[new_statuses_main_workflow]'
+        ) . ' ';
+
+        $checked = $module->options->new_statuses_main_workflow ? 'checked' : '';
+
+        echo sprintf(
+            '<input type="checkbox" name="%s" id="new_statuses_main_workflow" value="1" autocomplete="off" %s>',
+            esc_attr(\PublishPress_Statuses::SETTINGS_SLUG) . '[new_statuses_main_workflow]',
+            esc_attr($checked)
+        ) . ' ';
+
+        echo '<label for="new_statuses_main_workflow">';
+        esc_html_e('Add new statuses to Main Workflow by default', 'publishpress-statuses');
+        echo '</label>';
+
         echo '</div>';
     }
 


### PR DESCRIPTION
Also apply the same handling to new Revision Status.

closes #646